### PR TITLE
commit_and_restart_and_wait does not exist

### DIFF
--- a/start_config/handlers/main.yml
+++ b/start_config/handlers/main.yml
@@ -29,7 +29,7 @@
     lmi_port:  "{{ port | default(omit) }}"
     log:       "{{ log_level | default(omit) }}"
     force:     "{{ force | default(omit) }}"
-    action: ibmsecurity.isds.appliance.commit_and_restart_and_wait
+    action: ibmsecurity.isds.appliance.commit_and_restart
 
 # Commit and Restart may cause LMI to restart - so wait to be safe
 - name: Await Appliance Commit LMI Response
@@ -96,3 +96,4 @@
     log:       "{{ log_level | default(omit) }}"
     force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isds.base.lmi.restart_and_wait
+


### PR DESCRIPTION
A correction in start_config (isds) that I am pushing in behalf of the greath Francis who is returning to school.